### PR TITLE
config.toml.example: assume influxdb on localhost by default

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -1,6 +1,6 @@
 [influxdb]
 
-host = "10.0.3.195"
+host = "127.0.0.1"
 port = "8086"
 db = "ping"
 measurement = "ping"


### PR DESCRIPTION
localhost is probably a more convenient default